### PR TITLE
downloads: remove hardcoded github token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,4 @@ jobs:
         env:
           INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
           GLIF_TOKEN: ${{ secrets.GLIF_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/downloads.ts
+++ b/downloads.ts
@@ -1,6 +1,9 @@
 import { Application, Context } from "https://deno.land/x/oak@v11.1.0/mod.ts";
 import { oakCors } from "https://deno.land/x/cors@v1.2.2/mod.ts";
 import getRepositoryDownloadCount from "./lib/getRepositoryDownloadCount.ts";
+import { assert } from "https://deno.land/std@0.162.0/testing/asserts.ts";
+
+assert(Deno.env.get("GITHUB_TOKEN"), "$GITHUB_TOKEN required");
 
 const app = new Application();
 app.use(oakCors());
@@ -8,7 +11,7 @@ app.use(async (ctx: Context) => {
   ctx.response.body = {
     downloads: await getRepositoryDownloadCount(
       "filecoin-station/filecoin-station",
-      "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"
+      Deno.env.get("GITHUB_TOKEN")
     )
   }
 });


### PR DESCRIPTION
Afterwards we should be able to open source the repo (after deleting its history).

The secret was also configured in Deno Deploy